### PR TITLE
explicitly specify prettier rules and decouple from eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ A collection of lint, format, and build configs used at Fauna for TypeScript pro
 ## Included configs (`./config/`)
 - `eslint.config.js`, a minimal placeholder eslint config.
 - `.gitignore`, a minimal placeholder .gitignore file.
-- `prettierrc.js`, a minimal placeholder prettier config.
+- `prettierrc.js`, a minimal placeholder prettier config. this is a _stand-alone_ prettier config, and is used as a stand-alone; it's not integrated into eslint ([by choice](https://prettier.io/docs/en/integrating-with-linters.html)). run it before running eslint. we use [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) to remove eslint rules that collide with prettier, so prettier is authoritative on stylistic formatting.

--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -1,3 +1,5 @@
+const eslintConfigPrettier = require("eslint-config-prettier");
+
 // borrowed from fauna-shell
 const config = [
   {
@@ -32,6 +34,8 @@ const config = [
       "no-unused-expressions": "off",
     },
   },
+  // this disables eslint's formatting rules that collide with prettier's
+  eslintConfigPrettier,
 ];
 
-module.exports = config;
+module.exports = { config };

--- a/config/prettierrc.js
+++ b/config/prettierrc.js
@@ -1,12 +1,21 @@
 /**
  * @see https://prettier.io/docs/en/configuration.html
+ * @see https://prettier.io/docs/en/options
  * @type {import("prettier").Config}
  */
 const config = {
-  trailingComma: "es5",
-  tabWidth: 4,
-  semi: false,
-  singleQuote: true,
+  tabWidth: 2,
+  semi: true,
+  singleQuote: false,
+  quoteProps: "as-needed",
+  trailingComma: "all",
+  bracketSpacing: true,
+  bracketSameLine: false,
+  arrowParens: "always",
+  proseWrap: "preserve",
+  endOfLine: "lf",
+  embeddedLanguageFormatting: "auto",
+  singleAttributePerLine: false,
 };
 
 module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@fauna/typescript",
-  "version": "0.0.2",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fauna/typescript",
-      "version": "0.0.2",
+      "version": "0.0.6",
       "license": "MPL-2.0",
       "dependencies": {
+        "eslint-config-prettier": "^9.1.0",
         "mentions-regex": "^2.0.3",
         "parse-commit-message": "^5.0.4"
       },
@@ -456,6 +457,18 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/fauna/typescript#readme",
   "dependencies": {
+    "eslint-config-prettier": "^9.1.0",
     "mentions-regex": "^2.0.3",
     "parse-commit-message": "^5.0.4"
   },


### PR DESCRIPTION
this change decouples eslint and prettier (for reasoning, see: https://prettier.io/docs/en/integrating-with-linters.html).

it also proposes a prettier config with all of the commonplace rules explicitly set (instead of using the defaults).