### PR TITLE
propose new eslint rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 A collection of lint, format, and build configs used at Fauna for TypeScript projects.
 
 ## Included configs (`./config/`)
-- `eslint.config.js`, a minimal placeholder eslint config.
+- `eslint.config.js`, a minimal base eslint config.
+  - `js/eslint.config.js`, an extension of the base config intended for raw javascript projects.
 - `.gitignore`, a minimal placeholder .gitignore file.
-- `prettierrc.js`, a minimal placeholder prettier config. this is a _stand-alone_ prettier config, and is used as a stand-alone; it's not integrated into eslint ([by choice](https://prettier.io/docs/en/integrating-with-linters.html)). run it before running eslint. we use [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) to remove eslint rules that collide with prettier, so prettier is authoritative on stylistic formatting.
+- `prettierrc.js`, a base prettier config. this is a _stand-alone_ prettier config; it's not integrated into eslint ([by choice](https://prettier.io/docs/en/integrating-with-linters.html)). Run it before running eslint. We use [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) to remove eslint rules that collide with prettier, so prettier is authoritative on the formatting it can do.
+
+## Included scripts (`./script/`)
+- `eslint-formatter.js`, a custom eslint output formatter intended for estimating the cost of adding new rules to an eslint config. From a consumer of `@fauna/typescript`, run it like `npx eslint --format ./node_modules/@fauna/typescript/scripts/eslint-formatter.js .`.
+- `version-bump.js`, a script intended for use in CI environments to automatically version bump a npm package. Useful for packages that should be versioned and deployed on every merge to `main`.
+
+## Workflows
+
+### Development
+Develop on this package by running `npm install && npm link`. Then, navigate to a package that depends on this project and run `npm link @fauna/typescript`. [npm link](https://docs.npmjs.com/cli/v10/commands/npm-link) builds a symlink from the node_modules directory of the dependent package to `@fauna/typescript`, allowing you to develop locally in real time. When done, run `npm unlink @fauna/typescript` from any directory.

--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -1,6 +1,3 @@
-const eslintConfigPrettier = require("eslint-config-prettier");
-
-// borrowed from fauna-shell
 const config = [
   {
     ignores: ["**/node_modules", ".history"],
@@ -9,33 +6,35 @@ const config = [
     languageOptions: {
       ecmaVersion: 2020,
     },
-
-    rules: {
-      "no-await-in-loop": "off",
-      "new-cap": "off",
-      "quote-props": "off",
-      "no-negated-condition": "off",
-      "no-warning-comments": "off",
-      "spaced-comment": "off",
-      "max-nested-callbacks": "off",
-      "no-else-return": "off",
-      "no-console": "off",
-      "no-multi-str": "off",
-      "no-prototype-builtins": "off",
-
-      "node/no-unsupported-features": "off",
-      camelcase: "off",
-    },
   },
   {
     files: ["test/**/*.mjs"],
 
     rules: {
       "no-unused-expressions": "off",
+      "no-empty-function": "off",
+      "camelcase": "off",
     },
   },
-  // this disables eslint's formatting rules that collide with prettier's
-  eslintConfigPrettier,
 ];
 
-module.exports = { config };
+const sharedGlobals = {
+  console: "readonly",
+  URLSearchParams: "readonly",
+  Blob: "readonly",
+  URL: "readonly",
+  FormData: "readonly",
+  fetch: "readonly",
+};
+
+const nodeGlobals = {
+  ...sharedGlobals,
+  Buffer: "readonly",
+  process: "readonly",
+};
+
+const browserGlobals = {
+  ...sharedGlobals,
+};
+
+module.exports = { config, nodeGlobals, browserGlobals, };

--- a/config/js/eslint.config.js
+++ b/config/js/eslint.config.js
@@ -1,0 +1,107 @@
+const eslintConfigPrettier = require("eslint-config-prettier");
+const simpleImportSort = require("eslint-plugin-simple-import-sort");
+const js = require("@eslint/js");
+const { config: base, nodeGlobals: globals } = require("../eslint.config.js");
+
+// borrowed from fauna-shell
+const config = [
+  js.configs.recommended,
+  {
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals
+    },
+
+    rules: {
+      /* THESE ARE "POSSIBLE PROBLEMS" RULES, AND ALMOST ALL INDICATE SERIOUS RISK OF UNEXPECTED BEHAVIOR */
+      // these are off by default in the recommended ruleset, but I propose we turn them on
+      "array-callback-return": "error",
+      "no-duplicate-imports": ["error", {
+        "includeExports": true
+      }],
+      "no-promise-executor-return": "error",
+      "no-self-compare": "error",
+      "no-template-curly-in-string": "error",
+      "no-unmodified-loop-condition": "error",
+      "no-unreachable-loop": "error",
+      "no-use-before-define": ["error", { "functions": false }],
+      "require-atomic-updates": "error",
+
+      // this was off in our old ruleset, and I propose we turn it on
+      "no-await-in-loop": "warn",
+
+      // this is on in the recommended ruleset, but I propose we customize it slightly
+      "no-empty": ["error", { "allowEmptyCatch": true }],
+      "no-unused-vars": ["error", { "caughtErrors": "none" }],
+
+      // suggestion
+      /* THESE ARE "SUGGESTION" RULES, AND ARE A COMBINATION OF STYLE DECISIONS AND LESS-FREQUENT EDGE CASES */
+
+      // these are off by default in the recommended ruleset, but I propose we turn them on
+      "class-methods-use-this": "error",
+      "complexity": ["error", { max: 20 }],
+      "complexity": ["warn", { max: 10 }],
+      "consistent-return": "error",
+      "default-case": "error",
+      "default-case-last": "error",
+      "dot-notation": "error",
+      "eqeqeq": "error",
+      "max-depth": ["error", { max: 6 }],
+      "max-depth": ["warn", { max: 4 }],
+      "max-lines": ["warn", { max: 250 }],
+      "max-lines": ["error", { max: 500 }],
+      "max-params": ["error", { max: 4 }],
+      "no-alert": "error",
+      "no-caller": "error",
+      "no-empty-function": "error",
+      "no-extend-native": "error",
+      "no-implicit-coercion": "error",
+      "no-lone-blocks": "error",
+      "no-lonely-if": "error",
+      "no-loop-func": "error",
+      "no-object-constructor": "error",
+      "no-sequences": "error",
+      "no-throw-literal": "error",
+      "no-unused-expressions": "error",
+      "no-useless-call": "error",
+      "no-useless-concat": "error",
+      "no-var": "error",
+      "prefer-rest-params": "error",
+      "prefer-spread": "error",
+      "prefer-template": "error",
+      "sort-imports": ["error", {
+        "allowSeparatedGroups": true,
+      }],
+
+      // this was off in our old ruleset, and I propose we turn it on
+      camelcase: "error",
+      "new-cap": ["error", {
+        "capIsNewExceptions": [
+          // v4 built-in functions should be included in this list
+          "Now",
+        ]
+      }],
+      "no-warning-comments": "warn",
+      "no-console": "error",
+      "no-prototype-builtins": "off",
+
+
+      // "node/no-unsupported-features": "off",
+    },
+  },
+  ...base,
+  {
+    plugins: {
+      "simple-import-sort": simpleImportSort,
+    },
+    rules: {
+      "sort-imports": "off",
+      "simple-import-sort/imports": "error",
+      "simple-import-sort/exports": "error",
+    },
+  },
+  // this disables eslint's formatting rules that collide with prettier's
+  eslintConfigPrettier,
+];
+
+module.exports = { config };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,21 @@
 {
   "name": "@fauna/typescript",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fauna/typescript",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MPL-2.0",
       "dependencies": {
         "eslint-config-prettier": "^9.1.0",
         "mentions-regex": "^2.0.3",
         "parse-commit-message": "^5.0.4"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.13.0",
+        "eslint-plugin-simple-import-sort": "^12.1.1"
       },
       "peerDependencies": {
         "eslint": "^9.12.0",
@@ -111,7 +115,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.13.0.tgz",
       "integrity": "sha512-IFLyoY4d72Z5y/6o/BazFBezupzI/taV8sGumxTAVw3lXG9A6md1Dc34T9s1FoD/an9pJH8RHbAxsaEbBed9lA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -469,6 +472,16 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -32,5 +32,9 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.13.0",
+    "eslint-plugin-simple-import-sort": "^12.1.1"
   }
 }

--- a/scripts/eslint-formatter.js
+++ b/scripts/eslint-formatter.js
@@ -1,0 +1,65 @@
+/*
+  Intended to estimate the cost of adding new rules to an eslint config.
+  Produces output like:
+
+  Fixable errors (19 total; sorted alphabetically)
+    - no-var (error): 1
+    - prefer-template (error): 4
+    - sort-imports (error): 14
+
+  Not fixable (400 total; sorted alphabetically)
+    - camelcase (error): 54
+    - class-methods-use-this (error): 9
+    - complexity (warn): 7
+    - consistent-return (error): 3
+    - eqeqeq (error): 2
+    - new-cap (error): 1
+    - no-console (error): 17
+    - no-empty-function (error): 1
+    - no-undef (error): 2
+    - no-unused-vars (error): 3
+    - no-use-before-define (error): 14
+    - no-warning-comments (warn): 13
+    - sort-keys (error): 235
+*/
+
+function totalsFormatter(results) {
+  const errors = results.reduce((aggregate, file) => {
+    file.messages && file.messages.forEach((message) => {
+      if (!aggregate[message.ruleId]) {
+        aggregate[message.ruleId] = { unfixable: 0, fixable: 0, severity: message.severity };
+      }
+
+      if (message.fix) {
+        aggregate[message.ruleId].fixable++;
+      } else {
+        aggregate[message.ruleId].unfixable++;
+      }
+    });
+
+    return aggregate;
+  }, {});
+
+  const totalFixable = Object.values(errors).reduce((sum, error) => { return sum += error.fixable }, 0);
+  const totalUnfixable = Object.values(errors).reduce((sum, error) => { return sum += error.unfixable }, 0);
+
+  let fixableResults = "";
+  for (const [key, value] of Object.entries(errors)) {
+    if (value.fixable)
+      fixableResults += `\n  - ${key} (${value.severity === 2 ? "error" : "warn"}): ${value.fixable}`
+  }
+  let unfixableResults = "";
+  for (const [key, value] of Object.entries(errors)) {
+    if (!value.fixable)
+      unfixableResults += `\n  - ${key} (${value.severity === 2 ? "error" : "warn"}): ${value.unfixable}`
+  }
+
+
+  fixableResults = fixableResults.split('\n').sort((a, b) => a.localeCompare(b)).join('\n');
+  unfixableResults = unfixableResults.split('\n').sort((a, b) => a.localeCompare(b)).join('\n');
+  let result = `Fixable errors (${totalFixable} total; sorted alphabetically)${fixableResults}\n\n`;
+  result += `Not fixable (${totalUnfixable} total; sorted alphabetically)${unfixableResults}\n`;
+  return result;
+};
+
+module.exports = totalsFormatter;


### PR DESCRIPTION
this change:
- adds a proposed set of eslint rules
- updates the readme to document the dev workflow and new scripts/configs
- adds a JS-specific eslint config that extends the base eslint config
- adds a custom eslint formatter for estimating cost of introducing new config rules

it flags these errors when run against `fauna-shell`:
```
Fixable errors (19 total; sorted alphabetically)
  - no-var (error): 1
  - prefer-template (error): 4
  - sort-imports (error): 14

Not fixable (400 total; sorted alphabetically)
  - camelcase (error): 54
  - class-methods-use-this (error): 9
  - complexity (warn): 7
  - consistent-return (error): 3
  - eqeqeq (error): 2
  - new-cap (error): 1
  - no-console (error): 17
  - no-empty-function (error): 1
  - no-undef (error): 2
  - no-unused-vars (error): 3
  - no-use-before-define (error): 14
  - no-warning-comments (warn): 13
  - sort-keys (error): 235
 ```