### PR TITLE
update package-lock after build

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
-
 name: Publish to NPM
 
 on:
@@ -20,7 +17,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        # Fetch the last 2 commits instead of just 1. (Fetching just 1 commit would overwrite the whole history)
+        # Fetch the last 2 commits instead of just 1. (Fetching just 1 commit
+        # would overwrite the whole history)
         fetch-depth: 2
     - name: Use Node.js (22.x)
       uses: actions/setup-node@v4
@@ -35,11 +33,16 @@ jobs:
       run: |
         echo "message=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
         echo "author=$(git log -1 --pretty=\"%an <%ae>\")" >> $GITHUB_OUTPUT
-    # Commit changes to package.json back to the repository
+    # Commit changes to package.json and package-lock.json back to the
+    # repository Since we install dependencies with `npm ci`, the only update
+    # to package-lock should be updating the version of this package. If we
+    # don't commit that, the next dev to run `npm install` in the repo will
+    # have a package-lock.json change that updates the version to... the N-1
+    # version.
     - uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_author: ${{ steps.last-commit.outputs.author }}
-        file_pattern: 'package.json'
+        file_pattern: 'package.json package-lock.json'
         commit_message: ${{ steps.last-commit.outputs.message }}
         commit_options: '--amend --no-edit'
         push_options: '--force'


### PR DESCRIPTION
We need to commit changes to package.json and package-lock.json back to the repository. Since we install dependencies with `npm ci`, the only update to package-lock should be updating the version of this package. If we we don't commit that, the next dev to run `npm install` in the repo will have a package-lock.json change that updates the version to... the N-1 version.